### PR TITLE
社員の登録画面RegisterEmployee.phpを作成しました。

### DIFF
--- a/src/src/RegisterEmployee.php
+++ b/src/src/RegisterEmployee.php
@@ -1,3 +1,16 @@
 <?php
 
-echo 'a';
+namespace ShuffleLunch;
+
+require_once(__DIR__ . '/lib/Escape.php');
+require_once(__DIR__ . '/lib/Pdo.php');
+
+$employeeName = [
+  'name' => '',
+];
+$errors = [];
+$pdo = dbConnect();
+$employeeRegisters = getEmployeesRegister($pdo);
+$title = 'シャッフルランチサービス';
+$contents = __DIR__ . '/views/RegisterEmployee.php';
+include __DIR__ . '/views/Layout.php';

--- a/src/src/Shuffle.php
+++ b/src/src/Shuffle.php
@@ -11,22 +11,6 @@ require_once(__DIR__ . '/lib/Escape.php');
 
 const NUMBER_OF_DIVISION = 3;
 
-function getEmployeesRegister(PDO $pdo): array
-{
-  try {
-    $statement = $pdo->prepare('SELECT id,name FROM list_employees');
-    $statement->execute();
-    $results = [];
-    while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
-      $results[] = $row;
-    }
-    return $results;
-  } catch (PDOException $e) {
-    error_log('Error: fail to  get database information') . PHP_EOL;
-    error_log($e->getMessage());
-  }
-}
-
 function shuffleEmployeesRegister(array $employeesRegisters): array
 {
   shuffle($employeesRegisters);

--- a/src/src/lib/Pdo.php
+++ b/src/src/lib/Pdo.php
@@ -23,3 +23,19 @@ function dbConnect(): PDO
     error_log($e->getMessage());
   }
 }
+
+function getEmployeesRegister(PDO $pdo): array
+{
+  try {
+    $statement = $pdo->prepare('SELECT id,name FROM list_employees');
+    $statement->execute();
+    $results = [];
+    while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+      $results[] = $row;
+    }
+    return $results;
+  } catch (PDOException $e) {
+    error_log('Error: fail to  get database information') . PHP_EOL;
+    error_log($e->getMessage());
+  }
+}

--- a/src/src/views/Layout.php
+++ b/src/src/views/Layout.php
@@ -1,3 +1,19 @@
-<?php
+<!DOCTYPE html>
+<html lang="ja">
 
-include $contents;
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><?php echo $title ?></title>
+  <link rel="stylesheet" href="styleSheets/css/app.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+</head>
+
+<body>
+  <div class="container">
+    <a href=" /src/Top.php" class="fs-1 inline-block text-decoration-none">シャッフルランチ</a>
+    <?php include $contents; ?>
+  </div>
+</body>
+
+</html>

--- a/src/src/views/RegisterEmployee.php
+++ b/src/src/views/RegisterEmployee.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ShuffleLunch;
+
+require_once(__DIR__ . '/../lib/Escape.php');
+
+use function  ShuffleLunch\escape;
+?>
+
+<div class="container px-0">
+  <h2>社員の登録</h2>
+  <form action="create.php" method="POST">
+    <div>
+      <label for="name" class="fs-4">社員名</label>
+      <input type="text" class="form-control" name="name" id="name" value="<?php echo $employeeName['name']; ?>">
+    </div>
+    <button type="submit" class="btn btn-primary my-3">登録する</button>
+  </form>
+  <h2>社員の一覧</h2>
+  <div class="card">
+    <?php if (count($employeeRegisters) > 0) : ?>
+      <?php foreach ($employeeRegisters as $employeeRegister) : ?>
+        <div class="card-text fs-5">
+          <?php echo escape($employeeRegister['name']) . "(ID:" . $employeeRegister['id'] . ")"; ?>&nbsp;
+        </div>
+      <?php endforeach; ?>
+    <?php endif; ?>
+  </div>
+</div>

--- a/src/src/views/Top.php
+++ b/src/src/views/Top.php
@@ -4,40 +4,23 @@ require_once(__DIR__ . '/../lib/Escape.php');
 use function  ShuffleLunch\escape;
 ?>
 
-<!DOCTYPE html>
-<html lang="ja">
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><?php echo $title ?></title>
-  <link rel="stylesheet" href="styleSheets/css/app.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-</head>
-
-<body>
-  <div class="container">
-    <h1>シャッフルランチ</h1>
-    <div class="container px-0">
-      <a href="/src/RegisterEmployee.php" class="fs-2 inline-block text-decoration-none"><span class="fa-solid fa-user"></span>社員を登録する</a><br>
-      <button onclick="location.href= '/src/Shuffle.php'" type="button" class="btn btn-primary my-3">シャッフルする</button>
-      <h2>グループ結果</h2>
-      <div class="card">
-        <?php if (count($shuffleEmployeesRegisters) > 0) : ?>
-          <?php foreach ($shuffleEmployeesRegisters as $groupIndex => $group) : ?>
-            <div class="card-title">
-              グループ<?php echo ($groupIndex + 1); ?><br>
-              <div class="card-text">
-                <?php foreach ($group as $employee) : ?>
-                  <?php echo escape($employee['name']) . "(ID:" . $employee['id'] . ")"; ?>&nbsp;
-                <?php endforeach; ?>
-              </div>
-            </div>
-          <?php endforeach; ?>
-        <?php endif; ?>
-      </div>
-    </div>
+<div class="container px-0">
+  <a href="/src/RegisterEmployee.php" class="fs-2 inline-block text-decoration-none"><span class="fa-solid fa-user"></span>社員を登録する</a><br>
+  <button onclick="location.href= '/src/Shuffle.php'" type="button" class="btn btn-primary my-3">シャッフルする</button>
+  <h2>グループ結果</h2>
+  <div class="card">
+    <?php if (count($shuffleEmployeesRegisters) > 0) : ?>
+      <?php foreach ($shuffleEmployeesRegisters as $groupIndex => $group) : ?>
+        <div class="card-title">
+          グループ<?php echo ($groupIndex + 1); ?><br>
+          <div class="card-text">
+            <?php foreach ($group as $employee) : ?>
+              <?php echo escape($employee['name']) . "(ID:" . $employee['id'] . ")"; ?>&nbsp;
+            <?php endforeach; ?>
+          </div>
+        </div>
+      <?php endforeach; ?>
+    <?php endif; ?>
   </div>
-</body>
-
-</html>
+</div>


### PR DESCRIPTION
■RegisterEmployee.phpを作成
こちらのページでは、社員の登録を行うことができます。
・社員名の下にある入力フォームに社員名を入力し、登録するボタンをクリックすることで、Create.phpにページ遷移し、Create.phpにてデータベースに入力した社員名を登録します。
※今後、Create.phpでは、データベースに社員名を登録するロジックを実装していきます。

・社員の一覧では、データベースに登録されている社員名と社員IDが表示されます。

■データベース処理に関するメソッドをPdo.phpに移動させました。
Pdo.phpに、データベースから'name','id'カラムを取得し、配列に格納・配列を返すメソッドのgetEmployeesRegister()を
Shuffle.phpより移動させました。これにより、他のページにてPdo.phpを読み込むことで、getEmployeesRegister()を使い回せるようにしております。

■Layout.phpに共通コードを記述
Top.phpに記述されていたhtmlタグ、headタグ等の各ページにて共通に使用されるコードをLayout.phpに移動させました。
これにより、異なるページにて毎回これらの共通のコードを記述する必要をなくしております。