### PR TITLE
Shuffle.phpにて2~3名にグループ分けを行うようコードを修正しました。

### DIFF
--- a/src/src/Shuffle.php
+++ b/src/src/Shuffle.php
@@ -9,7 +9,8 @@ require_once(__DIR__ . '/lib/Pdo.php');
 require_once(__DIR__ . '/lib/Escape.php');
 
 
-const NUMBER_OF_DIVISION = 3;
+const NUMBER_OF_THREE_DIVISION = 3;
+const NUMBER_OF_TWO_DIVISION = 2;
 
 function shuffleEmployeesRegister(array $employeesRegisters): array
 {
@@ -20,7 +21,16 @@ function shuffleEmployeesRegister(array $employeesRegisters): array
 
 function splitOfArray(array $employeesRegisters): array
 {
-  $splitArray = array_chunk($employeesRegisters, NUMBER_OF_DIVISION);
+  $cnt = count($employeesRegisters);
+  if ($cnt % 3 === 0) {
+    $splitArray = array_chunk($employeesRegisters, NUMBER_OF_THREE_DIVISION);
+  } elseif ($cnt % 2 === 0) {
+    $splitArray = array_chunk($employeesRegisters, NUMBER_OF_TWO_DIVISION);
+  } else {
+    $extra = array_pop($employeesRegisters);
+    $splitArray = array_chunk($employeesRegisters, NUMBER_OF_TWO_DIVISION);
+    array_push($splitArray[0], $extra);
+  }
   return $splitArray;
 }
 


### PR DESCRIPTION
Shuffle.phpにて今までのロジックでは、3名ずつに分けて余りは1名または2名のグループとなっていましたが、splitOfArray()を修正して、下記のロジックに修正しました。
・社員数が3で割り切れる場合は、３名ずつにグループ分けを行う。
・社員数が2で割り切れる場合は、2名ずつにグループ分けを行う。
・社員数が3でも2でも割り切れない場合は、2名ずつにグループ分けを行い、余った1名を最初のグループに加える。