### PR TITLE
従業員情報の更新内容に対するバリデーション処理を実装しました。

### DIFF
--- a/src/models/Employee.php
+++ b/src/models/Employee.php
@@ -13,4 +13,9 @@ class Employee extends DatabaseModel
   {
     $this->execute('INSERT INTO list_employees (name) VALUES(?)', [$name]);
   }
+
+  public function update($updateEmployee, $selectEmployeeId)
+  {
+    $this->execute('UPDATE list_employees SET id = ?, name = ? WHERE id = ?;', [$updateEmployee['updateEmployeeId'], $updateEmployee['updateEmployeeName'], $selectEmployeeId]);
+  }
 }

--- a/src/views/employee/select.php
+++ b/src/views/employee/select.php
@@ -15,10 +15,10 @@ use function  ShuffleLunch\escape;
         </ul>
       <?php endif; ?>
       <select class="form-select" name="dropdownValue" aria-label="select employee" required>
-        <option value='default' selected>修正する社員を選択してください</option>
+        <option value="default" selected>修正する社員を選択してください</option>
         <?php if (count($employeeRegisters) > 0) : ?>
           <?php foreach ($employeeRegisters as $employeeRegister) : ?>
-            <option value='{"id": <?php echo escape($employeeRegister['id']); ?>, "name": <?php echo escape($employeeRegister['name']); ?>}' ?><?php echo escape($employeeRegister['name']) . "(ID:" . $employeeRegister['id'] . ")"; ?>&nbsp;</option>
+            <option value='{"id": <?php echo escape($employeeRegister['id']); ?>, "name": "<?php echo escape($employeeRegister['name']); ?>"}' ?><?php echo escape($employeeRegister['name']) . "(ID:" . $employeeRegister['id'] . ")"; ?>&nbsp;</option>
           <?php endforeach; ?>
       </select>
       <div class="card my-3">


### PR DESCRIPTION
■controller/ShuffleController.php
1.isIdExists()を追加したことで、更新するidが既に存在しているかを確認しております。
存在していた場合は、$errorsにエラー内容を格納し、画面に表示します。
2.選択した従業員情報の更新内容に対してcheckUpdate()バリデーション処理を実装しました。
このバリデーション処理では下記項目をチェックしております。
・名前のみ更新する場合は、更新するid($updateDetails['updateEmployeeId'])に選択した従業員id($selectEmployeeId)を格納
・idのみ更新する場合は、更新する従業員名($updateDetails['updateEmployeeName'])に選択した従業員名($selectEmployeeName)を格納
このバリデーション処理によって、Employee.phpのupdate()にてデータベースの従業員情報を更新する際に、更新が問題なく処理されるようにしております。